### PR TITLE
Revert "ci: dependabotの対象をexamplesも含めて実施する"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,7 @@ updates:
     cooldown:
       default-days: 7
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/packages/**"
-      - "/examples"
+    directory: "/"
     groups:
       all:
         patterns:


### PR DESCRIPTION
This reverts commit dbd3ba8de87e061a0a42ad516fefb05e0580475c.

exampleのpackage.jsonの変更がpnpm-lock.yamlに反映されないため、戻す